### PR TITLE
Co2.js integration

### DIFF
--- a/co2.js
+++ b/co2.js
@@ -15,27 +15,27 @@
  * limitations under the License.
  */
 
-/* exported getCo2eqPerByte */
+/* exported getCO2eqPerByte */
 
 /**
  * Environment-wide variable that will be overridden by the IIFE import.
  */
-let co2Library;
+let CO2Library;
 
 /**
- * Imports the co2 library using eval().
+ * Imports the CO2 library using eval().
  *
  * Note: eval() is a security risk, only used due to AS limitations.
  */
-function importCo2Library() {
-  if (typeof co2Library !== 'undefined') return;
+function importCO2Library() {
+  if (typeof CO2Library !== 'undefined') return;
   try {
     eval(
         UrlFetchApp
             .fetch(
-                'https://cdn.jsdelivr.net/npm/@tgwf/co2@latest/dist/iife/index.js')
+                'https://cdn.jsdelivr.net/npm/@tgwf/CO2@latest/dist/iife/index.js')
             .getContentText());
-    co2Library = co2;
+    CO2Library = CO2;
   } catch (error) {
     Logger.log(error);
   }
@@ -49,9 +49,6 @@ function importCo2Library() {
  *     false otherwise.
  */
 function checkGreenHosting(url) {
-  if (typeof co2Library === 'undefined') {
-    importCo2Library();
-  }
   const hostname = url.split('/')[2];
   const responseRaw = UrlFetchApp.fetch(
       `https://api.thegreenwebfoundation.org/greencheck/${hostname}`);
@@ -67,9 +64,9 @@ function checkGreenHosting(url) {
  *     take into account whether the URL is hosted on a green hosting provider.
  * @return {number} Estimated grams of CO2eq per byte.
  */
-function getCo2eqPerByte(totalBytes, url = '') {
-  if (typeof co2Library === 'undefined') {
-    importCo2Library();
+function getCO2eqPerByte(totalBytes, url = '') {
+  if (typeof CO2Library === 'undefined') {
+    importCO2Library();
   }
   // If the URL is specified, we check whether TGWF has data on type
   let isGreenHosting = false;
@@ -77,6 +74,6 @@ function getCo2eqPerByte(totalBytes, url = '') {
     isGreenHosting = checkGreenHosting(url);
   }
   // Then we proceed with the calculation
-  const co2Calculation = new co2Library.co2(); // eslint-disable-line new-cap
-  return co2Calculation.perByte(totalBytes, isGreenHosting);
+  const CO2Calculation = new CO2Library.CO2(); // eslint-disable-line new-cap
+  return CO2Calculation.perByte(totalBytes, isGreenHosting);
 }

--- a/co2.js
+++ b/co2.js
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* exported getCo2eqPerByte */
+
+/**
+ * Environment-wide variable that will be overridden by the IIFE import.
+ */
+let co2Library;
+
+/**
+ * Imports the co2 library using eval().
+ *
+ * Note: eval() is a security risk, only used due to AS limitations.
+ */
+function importCo2Library() {
+  if (typeof co2Library !== 'undefined') return;
+  try {
+    eval(
+        UrlFetchApp
+            .fetch(
+                'https://cdn.jsdelivr.net/npm/@tgwf/co2@latest/dist/iife/index.js')
+            .getContentText());
+    co2Library = co2;
+  } catch (error) {
+    Logger.log(error);
+  }
+}
+
+/**
+ * Checks whether the given URL is hosted on a green hosting provider.
+ *
+ * @param {string} url The URL to check.
+ * @return {boolean} True if the URL is hosted on a green hosting provider,
+ *     false otherwise.
+ */
+function checkGreenHosting(url) {
+  if (typeof co2Library === 'undefined') {
+    importCo2Library();
+  }
+  const hostname = url.split('/')[2];
+  const responseRaw = UrlFetchApp.fetch(
+      `https://api.thegreenwebfoundation.org/greencheck/${hostname}`);
+  const response = JSON.parse(responseRaw);
+  return response.green;
+}
+
+/**
+ * Calculates the CO2eq per byte for the given number of bytes and URL.
+ *
+ * @param {number} totalBytes The total number of bytes.
+ * @param {string} [url] The URL to check. If specified, the calculation will
+ *     take into account whether the URL is hosted on a green hosting provider.
+ * @return {number} Estimated grams of CO2eq per byte.
+ */
+function getCo2eqPerByte(totalBytes, url = '') {
+  if (typeof co2Library === 'undefined') {
+    importCo2Library();
+  }
+  // If the URL is specified, we check whether TGWF has data on type
+  let isGreenHosting = false;
+  if (typeof url !== 'undefined') {
+    isGreenHosting = checkGreenHosting(url);
+  }
+  // Then we proceed with the calculation
+  const co2Calculation = new co2Library.co2(); // eslint-disable-line new-cap
+  return co2Calculation.perByte(totalBytes, isGreenHosting);
+}

--- a/helper.js
+++ b/helper.js
@@ -382,7 +382,11 @@ function parseResults(content, budgets) {
       allResults.origin_fallback = true;
     }
   }
-  allResults.data = [...categories, ...audits, ...assets, version, ...crux];
+  const totalByteWeight =
+  lighthouseResult['audits']['total-byte-weight']['numericValue'];
+  const url = lighthouseResult['finalUrl'];
+  const co2eq = getCo2eqPerByte(totalByteWeight, url);
+  allResults.data = [...categories, ...audits, ...assets, version, ...crux, co2eq];
   return allResults;
 }
 

--- a/helper.js
+++ b/helper.js
@@ -385,8 +385,8 @@ function parseResults(content, budgets) {
   const totalByteWeight =
   lighthouseResult['audits']['total-byte-weight']['numericValue'];
   const url = lighthouseResult['finalUrl'];
-  const co2eq = getCo2eqPerByte(totalByteWeight, url);
-  allResults.data = [...categories, ...audits, ...assets, version, ...crux, co2eq];
+  const CO2eq = getCO2eqPerByte(totalByteWeight, url);
+  allResults.data = [...categories, ...audits, ...assets, version, ...crux, CO2eq];
   return allResults;
 }
 


### PR DESCRIPTION
Integrates CO2eq measurements to the results via the CO2.js library by The Green Web Foundation, also used by tooling such as WebPageTest.

This estimated result is appended to existing results - although the template should reflect this on the column's header, it doesn't conflict with previous versions.