### PR TITLE
[Readme]: Remove mention of third parties

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@ limitations under the License.
 ## Problem
 
 Many people require a lightweight solution for tracking their page performance.
-They also do not want to have to pay for anything to get started. The solutions
-currently available are either too complex for non-technical users (e.g. [AutoWebPerf](https://github.com/GoogleChromeLabs/AutoWebPerf)
-or sitespeed.io) or too expensive (e.g. speedcurve, calibre, etc.)
+They also do not want to have to pay for anything to get started.
 
 ## Solution
 


### PR DESCRIPTION
In this PR: 

- [x] Removes a paragraph from the start of the README problem statement

### Why this change? 

The problematic statement being that some alternatives are too technical or too expensive. That description mentions my company Calibre, and Speedcurve. Both of which are self-funded/bootstrapped companies from APAC.

I get that you want to describe your project, but please don't do it by calling out small self funded companies. Punch up.